### PR TITLE
Fix invalid HTML line break in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ### :cd: Operating Systems
 
-</br>
+<br/>
 
 <details><summary><h3> :open_file_folder: My Repositories </h3></summary>
 


### PR DESCRIPTION
## Summary
- fix invalid closing line break tag in README profile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f1cfb6964832296e2806a43eea61f